### PR TITLE
fix: support timestamp without "." symbol

### DIFF
--- a/utils/extractSentence.tsx
+++ b/utils/extractSentence.tsx
@@ -1,5 +1,5 @@
 export function extractSentence(sentence: string) {
   return sentence
     .replace("0:", "0.0") // 修复第0秒
-    .match(/\s*(\d+[\.:]\d+)(.*)/);
+    .match(/^\s*(\d+[\.:]?\d+?)([:：秒 ].*)/);
 }


### PR DESCRIPTION
调整正则，以便：
1. 支持“59秒”这样的正好整数、没有小数点的秒数。但是这样会识别到其他数字，所以增加识别限制：根据后缀来识别，包含常见的4种后缀[:：秒 ]
2. 前面增加“^”，对前面带有其他文字的数字，不识别为时间戳，避免转换文本中的其他小数。