### PR TITLE
fix: use explicit language names in prompts to prevent wrong output language

### DIFF
--- a/lib/openai/prompt.ts
+++ b/lib/openai/prompt.ts
@@ -1,6 +1,6 @@
 import { limitTranscriptByteLength } from '~/lib/openai/getSmallSizeTranscripts'
 import { VideoConfig } from '~/lib/types'
-import { DEFAULT_LANGUAGE, PROMPT_LANGUAGE_MAP } from '~/utils/constants/language'
+import { DEFAULT_LANGUAGE, LANGUAGE_CODE_TO_ENGLISH_NAME, PROMPT_LANGUAGE_MAP } from '~/utils/constants/language'
 
 interface PromptConfig {
   language?: string
@@ -37,6 +37,7 @@ export function getUserSubtitlePrompt(title: string, transcript: any, videoConfi
   const videoTitle = title?.replace(/\n+/g, ' ').trim()
   const videoTranscript = limitTranscriptByteLength(transcript).replace(/\n+/g, ' ').trim()
   const language = videoConfig.outputLanguage || DEFAULT_LANGUAGE
+  const languageName = LANGUAGE_CODE_TO_ENGLISH_NAME[language] || language
   const sentenceCount = videoConfig.sentenceNumber || 7
   const emojiTemplateText = videoConfig.showEmoji ? '[Emoji] ' : ''
   const emojiDescriptionText = videoConfig.showEmoji ? 'Choose an appropriate emoji for each bullet point. ' : ''
@@ -46,7 +47,7 @@ export function getUserSubtitlePrompt(title: string, transcript: any, videoConfi
   const outlineDescriptionText = shouldShowAsOutline
     ? `Use the outline list, which can have a hierarchical structure of up to ${videoConfig.outlineLevel} levels. `
     : ''
-  const prompt = `Your output should use the following template:\n## Summary\n## Highlights\n- ${emojiTemplateText}Bulletpoint${outlineTemplateText}\n\nYour task is to summarise the text I have given you in up to ${sentenceCount} concise bullet points, starting with a short highlight, each bullet point is at least ${wordsCount} words. ${outlineDescriptionText}${emojiDescriptionText}Use the text above: {{Title}} {{Transcript}}.\n\nReply in ${language} Language.`
+  const prompt = `Your output should use the following template:\n## Summary\n## Highlights\n- ${emojiTemplateText}Bulletpoint${outlineTemplateText}\n\nYour task is to summarise the text I have given you in up to ${sentenceCount} concise bullet points, starting with a short highlight, each bullet point is at least ${wordsCount} words. ${outlineDescriptionText}${emojiDescriptionText}Use the text above: {{Title}} {{Transcript}}.\n\nReply in ${languageName} Language.`
 
   return `Title: "${videoTitle}"\nTranscript: "${videoTranscript}"\n\nInstructions: ${prompt}`
 }
@@ -55,10 +56,11 @@ export function getUserSubtitleWithTimestampPrompt(title: string, transcript: an
   const videoTitle = title?.replace(/\n+/g, ' ').trim()
   const videoTranscript = limitTranscriptByteLength(transcript).replace(/\n+/g, ' ').trim()
   const language = videoConfig.outputLanguage || DEFAULT_LANGUAGE
+  const languageName = LANGUAGE_CODE_TO_ENGLISH_NAME[language] || language
   const sentenceCount = videoConfig.sentenceNumber || 7
   const emojiTemplateText = videoConfig.showEmoji ? '[Emoji] ' : ''
   const wordsCount = videoConfig.detailLevel ? (Number(videoConfig.detailLevel) / 100) * 2 : 15
-  const promptWithTimestamp = `Act as the author and provide exactly ${sentenceCount} bullet points for the text transcript given in the format [seconds] - [text] \nMake sure that:\n    - Please start by summarizing the whole video in one short sentence\n    - Then, please summarize with each bullet_point is at least ${wordsCount} words\n    - each bullet_point start with \"- \" or a number or a bullet point symbol\n    - each bullet_point should has the start timestamp, use this template: - seconds - ${emojiTemplateText}[bullet_point]\n    - there may be typos in the subtitles, please correct them\n    - Reply all in ${language} Language.`
+  const promptWithTimestamp = `Act as the author and provide exactly ${sentenceCount} bullet points for the text transcript given in the format [seconds] - [text] \nMake sure that:\n    - Please start by summarizing the whole video in one short sentence\n    - Then, please summarize with each bullet_point is at least ${wordsCount} words\n    - each bullet_point start with \"- \" or a number or a bullet point symbol\n    - each bullet_point should has the start timestamp, use this template: - seconds - ${emojiTemplateText}[bullet_point]\n    - there may be typos in the subtitles, please correct them\n    - Reply all in ${languageName} Language.`
   const videoTranscripts = limitTranscriptByteLength(JSON.stringify(videoTranscript))
   return `Title: ${videoTitle}\nTranscript: ${videoTranscripts}\n\nInstructions: ${promptWithTimestamp}`
 }

--- a/utils/constants/language.ts
+++ b/utils/constants/language.ts
@@ -13,4 +13,22 @@ export const PROMPT_LANGUAGE_MAP: { [key: string]: string } = {
   हिंदी: 'hi-IN',
 }
 
+// Maps locale codes to explicit English language names for use in AI prompts.
+// Using explicit names (e.g. "Simplified Chinese") instead of locale codes (e.g. "zh-CN")
+// reduces ambiguity and prevents the model from mixing up language variants.
+export const LANGUAGE_CODE_TO_ENGLISH_NAME: { [key: string]: string } = {
+  'en-US': 'English',
+  'zh-CN': 'Simplified Chinese',
+  'zh-TW': 'Traditional Chinese',
+  'ja-JP': 'Japanese',
+  'it-IT': 'Italian',
+  'de-DE': 'German',
+  'es-ES': 'Spanish',
+  'fr-FR': 'French',
+  'nl-NL': 'Dutch',
+  'ko-KR': 'Korean',
+  'km-KH': 'Khmer',
+  'hi-IN': 'Hindi',
+}
+
 export const DEFAULT_LANGUAGE = 'zh-CN'


### PR DESCRIPTION
Fixes #118

## Problem

When users select "中文" (Simplified Chinese) as the output language, the summarization prompt instructs the model with `Reply in zh-CN Language.` — using a locale code rather than a natural language name. This is ambiguous: the model may not consistently distinguish between `zh-CN` (Simplified) and `zh-TW` (Traditional), leading to occasional Traditional Chinese output even when Simplified Chinese is selected.

## Solution

Added a `LANGUAGE_CODE_TO_ENGLISH_NAME` mapping in `utils/constants/language.ts` that maps locale codes to explicit English language names:

- `zh-CN` → `Simplified Chinese`
- `zh-TW` → `Traditional Chinese`
- Other languages mapped similarly for clarity

Updated `getUserSubtitlePrompt` and `getUserSubtitleWithTimestampPrompt` in `lib/openai/prompt.ts` to use these unambiguous names in the `Reply in ... Language.` instruction.

Before: `Reply in zh-CN Language.`
After: `Reply in Simplified Chinese Language.`

## Testing

- Verified the `LANGUAGE_CODE_TO_ENGLISH_NAME` map covers all locales in `PROMPT_LANGUAGE_MAP`
- Falls back to the raw locale code for any unmapped value, maintaining backward compatibility