### PR TITLE
fix: remove spurious value="" from showTimestamp checkbox to fix localStorage persistence

### DIFF
--- a/components/PromptOptions.tsx
+++ b/components/PromptOptions.tsx
@@ -41,7 +41,7 @@ export function PromptOptions({
         </select>
       </div>
       <label className="relative inline-flex cursor-pointer items-center">
-        <input type="checkbox" value="" className="peer sr-only" {...register('showTimestamp')} />
+        <input type="checkbox" className="peer sr-only" {...register('showTimestamp')} />
         <div className="peer h-6 w-11 rounded-full bg-gray-200 after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-sky-400 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-sky-300 dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:ring-sky-800"></div>
         <span className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">是否显示时间戳</span>
       </label>


### PR DESCRIPTION
Fixes #68

## Problem

The `showTimestamp` checkbox in `PromptOptions.tsx` had a `value=""` attribute:

```tsx
<input type="checkbox" value="" className="peer sr-only" {...register('showTimestamp')} />
```

When `value=""` is set on a checkbox with react-hook-form, checking the box stores an empty string `""` instead of a boolean `true`. This breaks the `react-hook-form-persist` persistence round-trip: on page reload the value is restored as `""`, which does not re-check the box, so the user's "show timestamp" preference is silently lost.

The `showEmoji` checkbox (which reportedly *does* persist correctly) has no `value` attribute — this inconsistency was the root cause.

## Solution

Remove the redundant `value=""` attribute from the `showTimestamp` checkbox so it behaves as a boolean field, consistent with `showEmoji`.

```tsx
<input type="checkbox" className="peer sr-only" {...register('showTimestamp')} />
```

## Testing

1. Toggle "是否显示时间戳" ON, reload the page → checkbox should remain ON.
2. Toggle it OFF, reload → checkbox should remain OFF.
3. Verify "是否显示Emoji" still persists correctly (unchanged behaviour).